### PR TITLE
Fix ZarrWriter compilation: cast Img<?> to RandomAccessibleInterval

### DIFF
--- a/src/main/java/vtea/io/zarr/ZarrWriter.java
+++ b/src/main/java/vtea/io/zarr/ZarrWriter.java
@@ -222,7 +222,7 @@ public class ZarrWriter implements AutoCloseable {
         }
 
         // Write to Zarr
-        N5Utils.save(img, n5Writer, datasetName, chunkSize, compression, dataType);
+        N5Utils.save((RandomAccessibleInterval) img, n5Writer, datasetName, chunkSize, compression, dataType);
     }
 
     /**


### PR DESCRIPTION
The writeImageStack method had a type erasure issue where the Img<?> wildcard type couldn't be matched to N5Utils.save() signature. Added explicit cast to RandomAccessibleInterval to match the pattern used successfully in writeImagePlus method.